### PR TITLE
the current combination of maven plugin versions are causing ClassNotFoundException with maven 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,26 @@
+PATH
+  remote: .
+  specs:
+    vraptor-scaffold (1.2.0)
+      activesupport (= 3.0.1)
+      rake (= 0.9.2)
+      thor (= 0.14.6)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    ZenTest (4.4.0)
+    activesupport (3.0.1)
+    rake (0.9.2)
+    rcov (0.9.9)
+    rspec (1.3.2)
+    thor (0.14.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  ZenTest (= 4.4.0)
+  rcov (= 0.9.9)
+  rspec (= 1.3.2)
+  vraptor-scaffold!

--- a/lib/vraptor-scaffold/generators/app/templates/pom.erb
+++ b/lib/vraptor-scaffold/generators/app/templates/pom.erb
@@ -16,7 +16,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -25,7 +24,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.8</version>
 				<configuration>
 					<downloadSources>true</downloadSources>
 					<downloadJavadocs>true</downloadJavadocs>
@@ -35,12 +33,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.14</version>
 				<configuration>
 					<scanIntervalSeconds>3</scanIntervalSeconds>
 					<stopKey>foo</stopKey>
@@ -88,7 +84,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.5.1</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/spec/vraptor-scaffold/generators/app/templates/pom.xml
+++ b/spec/vraptor-scaffold/generators/app/templates/pom.xml
@@ -16,7 +16,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -25,7 +24,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.8</version>
 				<configuration>
 					<downloadSources>true</downloadSources>
 					<downloadJavadocs>true</downloadJavadocs>
@@ -35,12 +33,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.14</version>
 				<configuration>
 					<scanIntervalSeconds>3</scanIntervalSeconds>
 					<stopKey>foo</stopKey>
@@ -135,7 +131,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.5.1</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/spec/vraptor-scaffold/generators/plugin_generator/expected_configs/default_org_pom.xml
+++ b/spec/vraptor-scaffold/generators/plugin_generator/expected_configs/default_org_pom.xml
@@ -16,7 +16,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -25,7 +24,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.8</version>
 				<configuration>
 					<downloadSources>true</downloadSources>
 					<downloadJavadocs>true</downloadJavadocs>
@@ -35,12 +33,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.14</version>
 				<configuration>
 					<scanIntervalSeconds>3</scanIntervalSeconds>
 					<stopKey>foo</stopKey>
@@ -140,7 +136,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.5.1</version>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/spec/vraptor-scaffold/generators/plugin_generator/expected_configs/pom.xml
+++ b/spec/vraptor-scaffold/generators/plugin_generator/expected_configs/pom.xml
@@ -16,7 +16,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>
@@ -25,7 +24,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-eclipse-plugin</artifactId>
-				<version>2.8</version>
 				<configuration>
 					<downloadSources>true</downloadSources>
 					<downloadJavadocs>true</downloadJavadocs>
@@ -35,12 +33,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
-				<version>2.1.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>maven-jetty-plugin</artifactId>
-				<version>6.1.14</version>
 				<configuration>
 					<scanIntervalSeconds>3</scanIntervalSeconds>
 					<stopKey>foo</stopKey>
@@ -140,7 +136,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.5.1</version>
 			</plugin>
 		</plugins>
 	</reporting>


### PR DESCRIPTION
java.lang.ClassNotFoundException: org.apache.maven.toolchain.ToolchainManager
