### PR TITLE
property configuration 'generateRepository' for heroku on pom.xml prevent

### DIFF
--- a/lib/vraptor-scaffold/generators/app/templates/pom.erb
+++ b/lib/vraptor-scaffold/generators/app/templates/pom.erb
@@ -62,7 +62,6 @@
                         </goals>
                         <configuration>
                             <assembleDirectory>target</assembleDirectory>
-                            <generateRepository>false</generateRepository>
                             <extraJvmArguments>-Xmx512m</extraJvmArguments>
                             <programs>
                                 <program>

--- a/spec/vraptor-scaffold/generators/app/templates/pom-heroku.xml
+++ b/spec/vraptor-scaffold/generators/app/templates/pom-heroku.xml
@@ -61,7 +61,6 @@
                         </goals>
                         <configuration>
                             <assembleDirectory>target</assembleDirectory>
-                            <generateRepository>false</generateRepository>
                             <extraJvmArguments>-Xmx512m</extraJvmArguments>
                             <programs>
                                 <program>


### PR DESCRIPTION
property configuration 'generateRepository' for heroku on pom.xml prevents the app to build correctly
