### PR TITLE
fixing http request spec

### DIFF
--- a/spec/vraptor-scaffold/http_request_spec.rb
+++ b/spec/vraptor-scaffold/http_request_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'net/http'
 
 describe VraptorScaffold::HttpRequest do
   
@@ -11,9 +12,19 @@ describe VraptorScaffold::HttpRequest do
   end
 
   it "should use 'http_proxy' env when it is present" do
-    http = VraptorScaffold::HttpRequest.open_session "ajax.googleapis.com"
-    http.get("/ajax/libs/jquery/1/jquery.min.js") do |response|
-      response.should_not be_empty
+    http = VraptorScaffold::HttpRequest.http
+    http.should be_true http.proxy_class?
+  end
+
+  context "no proxy" do
+
+    before :each do
+      ENV.delete 'http_proxy'
+    end
+
+    it "should not use proxy settings when no http_proxy env exists" do
+      http = VraptorScaffold::HttpRequest.http
+      http.should be_true !http.proxy_class?
     end
   end
 

--- a/spec/vraptor-scaffold/http_request_spec.rb
+++ b/spec/vraptor-scaffold/http_request_spec.rb
@@ -1,14 +1,15 @@
 require "spec_helper"
-require 'net/http'
 
 describe VraptorScaffold::HttpRequest do
   
   before :each do
+    @http_proxy = ENV['http_proxy']
     ENV['http_proxy'] = "http://google.com"
   end
 
   after :each do
     ENV.delete 'http_proxy'
+    ENV['http_proxy'] = @http_proxy
   end
 
   it "should use 'http_proxy' env when it is present" do
@@ -20,6 +21,10 @@ describe VraptorScaffold::HttpRequest do
 
     before :each do
       ENV.delete 'http_proxy'
+    end
+
+    after :each do
+      ENV['http_proxy'] = @http_proxy
     end
 
     it "should not use proxy settings when no http_proxy env exists" do


### PR DESCRIPTION
fixed the spec that do not run on my machine over proxy.
Please, verify a added spec that contains the following assert:

http.should be_true !http.proxy_class?

i could not use:

http.should be_false http.proxy_class?

it broke the test. :/ know why?
