### PR TITLE
Alteração na versão do XStream

### DIFF
--- a/lib/vraptor-scaffold/generators/app/dependency/default_dependencies.rb
+++ b/lib/vraptor-scaffold/generators/app/dependency/default_dependencies.rb
@@ -32,7 +32,7 @@ class DefaultDependencies
 									Dependency.new("org.hibernate", "hibernate-c3p0", hibernate_version),
 									Dependency.new("org.hibernate", "hibernate-validator", "4.2.0.Final"),
 									Dependency.new("joda-time", "joda-time", "2.0"),
-									Dependency.new("com.thoughtworks.xstream", "xstream", "1.4.1")]
+									Dependency.new("com.thoughtworks.xstream", "xstream", "1.3.1")]
 
     dependencies
   end

--- a/lib/vraptor-scaffold/generators/app/dependency/gae_dependencies.rb
+++ b/lib/vraptor-scaffold/generators/app/dependency/gae_dependencies.rb
@@ -27,7 +27,7 @@ class GaeDependencies
 		  Dependency.new("javax.servlet", "jstl", "1.2"),
 		  Dependency.new("org.hibernate", "hibernate-validator", "4.2.0.Final"),
 		  Dependency.new("joda-time", "joda-time", "2.0"),
-		  Dependency.new("com.thoughtworks.xstream", "xstream", "1.4.1")]
+		  Dependency.new("com.thoughtworks.xstream", "xstream", "1.3.1")]
 
 		appengine_version = "1.7.2.1"
 		dependencies += [Dependency.new("com.googlecode.objectify", "objectify", "3.1"),

--- a/lib/vraptor-scaffold/generators/app/dependency/heroku_dependencies.rb
+++ b/lib/vraptor-scaffold/generators/app/dependency/heroku_dependencies.rb
@@ -32,7 +32,7 @@ class HerokuDependencies
 									Dependency.new("org.hibernate", "hibernate-c3p0", hibernate_version),
 									Dependency.new("org.hibernate", "hibernate-validator", "4.2.0.Final"),
 									Dependency.new("joda-time", "joda-time", "2.0"),
-									Dependency.new("com.thoughtworks.xstream", "xstream", "1.4.1")]
+									Dependency.new("com.thoughtworks.xstream", "xstream", "1.3.1")]
 
 		#heroku
 		dependencies += [Dependency.new("org.eclipse.jetty", "jetty-webapp", "7.4.4.v20110707"),


### PR DESCRIPTION
Foi alterada a versão do XStream de 1.4.1 para 1.3.1 nas dependência.
Com a versão mais nova, estava tendo problemas na serialização de JSON
